### PR TITLE
Make the xml namespace always known

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,8 @@ const sax = require('sax');
 const slimdom = require('slimdom');
 
 const defaultNamespaceMapping = {
-	'': null
+	'': null,
+	'xml': 'http://www.w3.org/XML/1998/namespace'
 };
 
 /*

--- a/index.test.js
+++ b/index.test.js
@@ -109,3 +109,12 @@ it('be gentle', () => {
 	expect(subject.getAttribute('blyat')).toBe('kurwa');
 	expect(subject.hasAttribute('ns0:blyat')).toBe(false);
 });
+
+it('knows the always-defined xml namespace', () => {
+	const doc = sync(`<root xml:lang="pl" />`);
+
+	const subject = doc.documentElement; // <a:root>
+
+	expect(subject.getAttributeNS('http://www.w3.org/XML/1998/namespace', 'lang')).toBe('pl');
+	expect(subject.getAttribute('xml:lang')).toBe('pl');
+});


### PR DESCRIPTION
The XML namespace is a strange duck in the bite: it is always known.