### PR TITLE
Dependency for XML parser changed to saxes

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-const sax = require('sax');
+const saxes = require('saxes');
 const slimdom = require('slimdom');
 
 const defaultNamespaceMapping = {
@@ -14,9 +14,6 @@ function createHandler () {
 
 	// Is rewritten as the handler traverses in and out of nodes
 	let dom = doc;
-
-	// Rewritten to accumulate a text stream
-	let cdata = null;
 
 	const namespaces = [defaultNamespaceMapping];
 	let currentNamespaces = Object.create(defaultNamespaceMapping);
@@ -66,10 +63,10 @@ function createHandler () {
 		},
 
 		onProcessingInstruction: (pi) => {
-			if (pi.name === 'xml' && dom.nodeType === dom.DOCUMENT_NODE) {
+			if (pi.target === 'xml' && dom.nodeType === dom.DOCUMENT_NODE) {
 				return;
 			}
-			dom.appendChild(doc.createProcessingInstruction(pi.name, pi.body));
+			dom.appendChild(doc.createProcessingInstruction(pi.target, pi.body));
 		},
 
 		onComment: (comment) => {
@@ -91,17 +88,8 @@ function createHandler () {
 			));
 		},
 
-		onOpenCdata: () => {
-			cdata = '';
-		},
-
 		onCdata: (string) => {
-			cdata += string;
-		},
-
-		onCloseCdata: () => {
-			dom.appendChild(doc.createCDATASection(cdata));
-			cdata = null;
+			dom.appendChild(doc.createCDATASection(string));
 		},
 
 		getDocument: () => {
@@ -124,7 +112,7 @@ exports.sync = function synchronousSlimdomSaxParser (xml) {
 	const handler = createHandler();
 
 	// Set up the sax parser
-	const parser = sax.parser(true, {
+	const parser = new saxes.SaxesParser({
 		xmlns: true
 	});
 

--- a/index.test.js
+++ b/index.test.js
@@ -86,7 +86,7 @@ it('namespaced elements', () => {
 	const subject = doc.documentElement.firstChild.nextSibling;
 
 	expect(() => sync(`<xml un:declared="test" />`))
-		.toThrow('Namespace prefix "un" not known for attribute "un:declared"');
+		.toThrow('unbound namespace prefix: "un".');
 
 	expect(subject.nodeType).toBe(types.ELEMENT_NODE);
 

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "sax": "^1.2.4",
+    "saxes": "^3.1.1",
     "slimdom": "^2.1.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Sax-JS had a bug where it ignored empty comments and CDATA.
https://github.com/isaacs/sax-js/pull/231

Saxes is another sax parser which fixes this bug.
https://github.com/lddubeau/saxes