### PR TITLE
Parse namespace declarations as attributes

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,8 @@ const slimdom = require('slimdom');
 
 const defaultNamespaceMapping = {
 	'': null,
-	'xml': 'http://www.w3.org/XML/1998/namespace'
+	'xml': 'http://www.w3.org/XML/1998/namespace',
+	'xmlns': 'http://www.w3.org/2000/xmlns/'
 };
 
 /*
@@ -40,13 +41,17 @@ function createHandler () {
 			// Set attributes, taking the accumulated namespace information into account
 			Object.keys(node.attributes)
 				.map(name => node.attributes[name])
-				.filter(attr => attr.prefix !== 'xmlns' && !(attr.prefix === '' && attr.name === 'xmlns'))
 				.forEach(attr => {
-					if (currentNamespaces[attr.prefix] === undefined) {
+					let namespaceURI = attr.prefix === '' ? null : currentNamespaces[attr.prefix];
+					// Default namespace declarations have no prefix but are in the XMLNS namespace
+					if (attr.prefix === '' && attr.name === 'xmlns') {
+						namespaceURI = currentNamespaces['xmlns'];
+					}
+					if (namespaceURI === undefined) {
 						throw new Error(`Namespace prefix "${attr.prefix}" not known for attribute "${attr.name}"`);
 					}
 
-					dom.setAttributeNS(attr.prefix === '' ? null : currentNamespaces[attr.prefix], attr.name, attr.value);
+					dom.setAttributeNS(namespaceURI, attr.name, attr.value);
 			});
 		},
 

--- a/index.test.js
+++ b/index.test.js
@@ -97,10 +97,15 @@ it('namespaced elements', () => {
 it('namespaced attributes', () => {
 	const subject = doc.documentElement.firstChild.nextSibling; // <a:root>
 
+	expect(subject.getAttributeNS(null, 'attr')).toBe('def');
 	expect(subject.getAttributeNS('http://default', 'attr')).toBeNull();
 	expect(subject.getAttribute('attr')).toBe('def');
 	expect(subject.getAttributeNS('http://a', 'attr')).toBe('A');
 	expect(subject.getAttributeNS('http://b', 'attr')).toBe('B');
+
+	// Declarations are attributes as well
+	expect(subject.getAttributeNS('http://www.w3.org/2000/xmlns/', 'xmlns')).toBe('http://default');
+	expect(subject.getAttributeNS('http://www.w3.org/2000/xmlns/', 'a')).toBe('http://a');
 
 	// Assert overriding namespace prefixes
 	expect(subject.firstChild.nodeName).toBe('a:child');


### PR DESCRIPTION
As some DOM methods such as Node#lookupNamespaceURI depend on namespace
declarations existing in the DOM as attribute nodes, filtering these out
causes such methods to not work as expected. This preserves declarations
and ensures the corresponding attributes are created in the correct
namespace.