### PR TITLE
Update saxes to 4.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,14 +10,21 @@
 	},
 	"license": "MIT",
 	"homepage": "https://github.com/wvbe/slimdom-sax-parser",
-	"keywords": [ "xml", "parse", "sax", "slimdom", "jsdom", "dom" ],
+	"keywords": [
+		"xml",
+		"parse",
+		"sax",
+		"slimdom",
+		"jsdom",
+		"dom"
+	],
 	"main": "index.js",
 	"scripts": {
 		"test": "jest",
 		"test-report": "jest --verbose --coverage"
 	},
 	"dependencies": {
-		"saxes": "^3.1.10",
+		"saxes": "^4.0.2",
 		"slimdom": "^2.3.1"
 	},
 	"devDependencies": {

--- a/test/parsing.test.js
+++ b/test/parsing.test.js
@@ -26,7 +26,7 @@ const doc = sync(
 		`<!DOCTYPE something PUBLIC "-//example doctype//EN" "http://www.example.org/ns">`,
 		`<?pi-target pi-data?>`,
 		`<!-- comment -->`,
-		`<root attr="val">`,
+		`<root attr="val" whitespace="before\n\r\r\r\nafter">`,
 		`<contains-text>text</contains-text>`,
 		`<a:root xmlns="http://default" xmlns:a="http://a" xmlns:b="http://b" xmlns:d="http://d" a:attr="A" b:attr="B" attr="def">`,
 		`<a:child xmlns:c="http://a" xmlns:a="http://b" c:attr="A" a:attr="B" d:attr="d" attr="def" />`,
@@ -78,6 +78,10 @@ it('attributes', () => {
 	const subject = evaluateXPath('/element()', doc);
 	expect(subject.attributes[0].nodeType).toBe(types.ATTRIBUTE_NODE);
 	expect(subject.getAttribute('attr')).toBe('val');
+});
+
+it('whitespace normalization in attributes', () => {
+	expect(doc.documentElement.getAttribute('whitespace')).toBe('before    after');
 });
 
 it('text outside the root node will throw an error', () => {


### PR DESCRIPTION
Saxes 4.0 fixes a number of whitespace / newline normalization issues.

Note that this is considered to have some breaking changes, which do affect whitespace in the DOM generated: https://github.com/lddubeau/saxes/blob/master/CHANGELOG.md#breaking-changes