### PR TITLE
Add .closePosition to Element nodes. Fix Text node positions when containing encoded entities.

### DIFF
--- a/src/createHandler.ts
+++ b/src/createHandler.ts
@@ -41,7 +41,9 @@ export default function createHandler(parser: SaxesParser, options: SaxesOptions
 	// Helpers for other responsibilities
 	const namespaces = createNamespaceContext(options.additionalNamespaces || {});
 
-	const [track, update] = options.position ? createPositionTracker(parser) : positionTrackerStubs;
+	const [track, trackClose, update] = options.position
+		? createPositionTracker(parser)
+		: positionTrackerStubs;
 
 	// Return a bunch of methods that can be applied directly to a saxes parser instance.
 	return {
@@ -92,7 +94,7 @@ export default function createHandler(parser: SaxesParser, options: SaxesOptions
 
 		onCloseTag: () => {
 			// Update position tracking so that the closing tag of an element is not prepended to the following sibling
-			update();
+			trackClose(contextNode);
 
 			if (!contextNode.parentNode) {
 				throw new Error('End of the line!');


### PR DESCRIPTION
Previously the only position information available on an element was the start/end/line/column position of the open tag, this adds a new `.closePosition` property to element nodes which contains the start/end/line/column of the close tag.

Also fixes an issue with Text node length, which was incorrect when there were encoded entities.