### PR TITLE
Add end position to attributes

### DIFF
--- a/src/asynchronouslyParseSlimdomDocument.ts
+++ b/src/asynchronouslyParseSlimdomDocument.ts
@@ -26,6 +26,7 @@ export function async(
 		// opentagstart
 		// attribute
 		parser.on('opentag', handler.onOpenTag);
+		parser.on('opentagstart', handler.onOpenTagStart);
 		parser.on('closetag', handler.onCloseTag);
 		parser.on('cdata', handler.onCdata);
 		parser.on('error', error => {

--- a/src/asynchronouslyParseSlimdomDocument.ts
+++ b/src/asynchronouslyParseSlimdomDocument.ts
@@ -18,22 +18,22 @@ export function async(
 		const parser = new saxes.SaxesParser(mergedOptions);
 		const handler = createHandler(parser, mergedOptions);
 
-		parser.on('text', handler.onText);
-		// xmldecl
-		parser.on('processinginstruction', handler.onProcessingInstruction);
-		parser.on('doctype', handler.onDocType);
-		parser.on('comment', handler.onComment);
+		// end
 		// opentagstart
-		// attribute
-		parser.on('opentag', handler.onOpenTag);
-		parser.on('opentagstart', handler.onOpenTagStart);
-		parser.on('closetag', handler.onCloseTag);
+		// ready
+		// xmldecl
+		parser.on('attribute', handler.onAttribute);
 		parser.on('cdata', handler.onCdata);
+		parser.on('closetag', handler.onCloseTag);
+		parser.on('comment', handler.onComment);
+		parser.on('doctype', handler.onDocType);
 		parser.on('error', error => {
 			reject(error);
 		});
-		// end
-		// ready
+		parser.on('opentag', handler.onOpenTag);
+		parser.on('opentagstart', handler.onOpenTagStart);
+		parser.on('processinginstruction', handler.onProcessingInstruction);
+		parser.on('text', handler.onText);
 
 		// @TODO remove ths and methods on handler
 		// parser.on('closecdata', handler.onCloseCdata);

--- a/src/createHandler.ts
+++ b/src/createHandler.ts
@@ -98,7 +98,7 @@ export default function createHandler(parser: SaxesParser, options: SaxesOptions
 					const position = attributePositions.get(attr.name)!;
 					const attributeNode = trackAttributePosition(
 						document.createAttributeNS(namespaceURI!, attr.name),
-						position!
+						position
 					);
 					attributeNode.value = attr.value;
 					node.setAttributeNode(attributeNode);

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,5 +2,5 @@
 import * as _slimdom from 'slimdom';
 export const slimdom = _slimdom;
 
-export * from './asynchronouslyParseSlimdomDocument';
-export * from './synchronouslyParseSlimdomDocument';
+export { async } from './asynchronouslyParseSlimdomDocument';
+export { sync } from './synchronouslyParseSlimdomDocument';

--- a/src/synchronouslyParseSlimdomDocument.ts
+++ b/src/synchronouslyParseSlimdomDocument.ts
@@ -12,25 +12,19 @@ export function sync(xml: string, options?: SlimdomSaxParserOptions) {
 	const parser = new saxes.SaxesParser(mergedOptions);
 	const handler = createHandler(parser, mergedOptions);
 
-	parser.on('text', handler.onText);
+	// end
+	// error
+	// ready
 	// xmldecl
-	parser.on('processinginstruction', handler.onProcessingInstruction);
-	parser.on('doctype', handler.onDocType);
-	parser.on('comment', handler.onComment);
-	// opentagstart
-	// attribute
-	parser.on('opentag', handler.onOpenTag);
-	parser.on('opentagstart', handler.onOpenTagStart);
-	parser.on('closetag', handler.onCloseTag);
 	parser.on('attribute', handler.onAttribute);
 	parser.on('cdata', handler.onCdata);
-	// error
-	// end
-	// ready
-
-	// @TODO remove ths and methods on handler
-	// parser.on('closecdata', handler.onCloseCdata);
-	// parser.on('opencdata', handler.onOpenCdata);
+	parser.on('closetag', handler.onCloseTag);
+	parser.on('comment', handler.onComment);
+	parser.on('doctype', handler.onDocType);
+	parser.on('opentag', handler.onOpenTag);
+	parser.on('opentagstart', handler.onOpenTagStart);
+	parser.on('processinginstruction', handler.onProcessingInstruction);
+	parser.on('text', handler.onText);
 
 	if (options !== undefined && options.additionalEntities !== undefined) {
 		for (const [entity, entityValue] of Object.entries(options.additionalEntities)) {

--- a/src/synchronouslyParseSlimdomDocument.ts
+++ b/src/synchronouslyParseSlimdomDocument.ts
@@ -20,7 +20,9 @@ export function sync(xml: string, options?: SlimdomSaxParserOptions) {
 	// opentagstart
 	// attribute
 	parser.on('opentag', handler.onOpenTag);
+	parser.on('opentagstart', handler.onOpenTagStart);
 	parser.on('closetag', handler.onCloseTag);
+	parser.on('attribute', handler.onAttribute);
 	parser.on('cdata', handler.onCdata);
 	// error
 	// end

--- a/test/position-tracking.test.ts
+++ b/test/position-tracking.test.ts
@@ -257,6 +257,10 @@ it('attributes', () => {
 
 	expect(test7.value).toBe('val7');
 	expect(test7.position.end).toBe(40 + 13 + 15 + 17 + 15 + 22 + 16);
+
+	// Duplicately defined attributes do not need to be tested on position tracking, because saxes
+	// would error out on it.
+	expect(() => sync(`<x a="b" a="b" />`)).toThrow('duplicate attribute');
 });
 
 it('text nodes', () => {

--- a/test/position-tracking.test.ts
+++ b/test/position-tracking.test.ts
@@ -1,4 +1,4 @@
-import { evaluateXPath } from 'fontoxpath';
+import { evaluateXPath, evaluateXPathToNodes } from 'fontoxpath';
 import { sync } from '../src/index';
 
 // Make the tests STFU
@@ -219,6 +219,44 @@ describe('elements', () => {
 		expect(context.closePosition.line).toBe(1);
 		expect(context.closePosition.column).toBe(19);
 	});
+});
+
+it('attributes', () => {
+	const xml = `<bar xmlns:x="http://skeet" test1="val1" test2="val2"   test3="val3"     test4="val4"
+		test5="val5" test6="va
+
+			l
+
+		6"  x:test7="val7"
+	/>`;
+	const doc = sync(xml, { position: true });
+
+	const [test1, test2, test3, test4, test5, test6, test7] = evaluateXPathToNodes(
+		'/*/attribute()',
+		doc
+	) as PositionTrackedNode;
+
+	expect(test1.value).toBe('val1');
+	expect(test1.position.end).toBe(40);
+
+	expect(test2.value).toBe('val2');
+	expect(test2.position.end).toBe(40 + 13);
+
+	expect(test3.value).toBe('val3');
+	expect(test3.position.end).toBe(40 + 13 + 15);
+
+	expect(test4.value).toBe('val4');
+	expect(test4.position.end).toBe(40 + 13 + 15 + 17);
+
+	expect(test5.value).toBe('val5');
+	expect(test5.position.end).toBe(40 + 13 + 15 + 17 + 15);
+
+	//  Newlines and tabs are each converted to a single space
+	expect(test6.value).toBe('va     l    6');
+	expect(test6.position.end).toBe(40 + 13 + 15 + 17 + 15 + 22);
+
+	expect(test7.value).toBe('val7');
+	expect(test7.position.end).toBe(40 + 13 + 15 + 17 + 15 + 22 + 16);
 });
 
 it('text nodes', () => {

--- a/test/position-tracking.test.ts
+++ b/test/position-tracking.test.ts
@@ -1,5 +1,5 @@
 import { evaluateXPath, evaluateXPathToNodes } from 'fontoxpath';
-import { sync } from '../src/index';
+import { sync, async } from '../src/index';
 
 // Make the tests STFU
 type PositionTrackedNode = any;
@@ -261,6 +261,16 @@ it('attributes', () => {
 	// Duplicately defined attributes do not need to be tested on position tracking, because saxes
 	// would error out on it.
 	expect(() => sync(`<x a="b" a="b" />`)).toThrow('duplicate attribute');
+});
+
+it('async attributes', async () => {
+	const xml = `<bar xmlns:x="http://skeet" test1="val1" />`;
+	const doc = await async(xml, { position: true });
+
+	const [test1] = evaluateXPathToNodes('/*/attribute()', doc) as PositionTrackedNode;
+
+	expect(test1.value).toBe('val1');
+	expect(test1.position.end).toBe(40);
 });
 
 it('text nodes', () => {

--- a/test/stream.test.ts
+++ b/test/stream.test.ts
@@ -114,7 +114,7 @@ it('Honors options in when asynchronously parsing xml', async () => {
 
 	const context = doc.firstChild;
 	const contextXml = `<!DOCTYPE test PUBLIC "test" "test">`;
-	const position = (context as PositionTrackedNode).position;
+	const position = (context as PositionTrackedNode<Element>).position;
 	expect(xmlContent.substring(position.start, position.end)).toBe(contextXml);
 	expect(position.start).toBe(0);
 	expect(position.end).toBe(36);


### PR DESCRIPTION
I was wondering whether it might be possible to add positions to attribute nodes.

`xmldom` is able to provide `lineNumber` and `columnNumber` for attribute nodes, but it seems like that's only possible because the sax parser in `xmldom` has a locator which keeps track of when attributes start.

I was able to get as far as adding an end position, but it seems like it's going to be tricky using `saxes` to get the start position.  I've asked in the `saxes` repository whether it might be possible to [add an `attributestart` event](https://github.com/lddubeau/saxes/issues/106), from which the start position (offset, at least) could be calculated.

I originally thought that calculating the start position by subtracting the length of the attribute name and value from the end position would be unreliable as there could be extra whitespace between them, but maybe that's actually fine, in which case providing just the end position would be enough.

This PR can probably be simplified - in brief it's listening for the "attribute" event (fired at the end of the attribute), storing the attribute name and current position, then setting that position on the attribute node when it's added to the parent node in the "opentag" event handler.

